### PR TITLE
Fix indentations for Native functions

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -70,7 +70,7 @@ function formatPapyrusCode(unformattedCode: string) {
   let currentIndentLevel = 0;
 
   // Regular expression to identify the start of a block (function or if statement)
-  const blockStartRegex = /^(Event|Function|if) .+\)/i;
+  const blockStartRegex = /^(Event|if) .+\)|^Function .+\)(?!.*\bNative\b)/i;
 
   // Regular expression to identify the end of a block
   const blockEndRegex = /^(EndEvent|EndFunction|endIf)/i;

--- a/unformatted.psc
+++ b/unformatted.psc
@@ -34,3 +34,15 @@ SetCursorFillMode(TOP_TO_BOTTOM)
 SetCursorFillMode(TOP_TO_BOTTOM)
 
 ; This line should stay here
+
+Function LogInfo(String message) Global Native
+Function LogWarn(String message) Global Native
+Function LogError(String message) Global Native
+Function LogDebug(String message) Global Native
+Int Function CreateSoundEvent(String name) Global Native
+Function AddStringVariableToSoundEvent(Int handle, String name, String value) Global Native
+Function AddIntVariableToSoundEvent(Int handle, String name, Int _value) Global Native
+Function AddFloatVariableToSoundEvent(Int handle, String _name, Float value) Global Native
+Function AddBoolVariableToSoundEvent(Int handle, String name, Bool _value) Global Native
+Function AddFormVariableToSoundEvent(Int handle, String name, Form _value) Global Native
+Function SendSoundEvent(Int handle) Global Native


### PR DESCRIPTION
Native functions do not expect a closing-keyword.

This fixes the formatter incorrectly indenting anything that comes after native functions.

Would close #1